### PR TITLE
Add no_log to Copy certificates task

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -40,6 +40,7 @@
     group: root
   with_items:
     - "{{ etcd_certificates }}"
+  no_log: true
   tags:
     - etcd
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -40,7 +40,7 @@
     group: root
   with_items:
     - "{{ etcd_certificates }}"
-  no_log: true
+  no_log: '{{ ansible_verbosity < 3 }}'
   tags:
     - etcd
 


### PR DESCRIPTION
This task leaks private keys in logs at copy. Setting no_log: true to
avoid this.