### PR TITLE
Variable etcd ansible group

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ Role Variables
 # "/home/da_user/etcd-certificates".
 etcd_ca_conf_directory: "{{ '~/etcd-certificates' | expanduser }}"
 
+# etcd ansible group
+etcd_ansible_group: "k8s_etcd"
 # etcd version
 etcd_version: "3.5.1"
 # Port where etcd listening for clients

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Role Variables
 # "/home/da_user/etcd-certificates".
 etcd_ca_conf_directory: "{{ '~/etcd-certificates' | expanduser }}"
 
-# etcd ansible group
+# etcd Ansible group
 etcd_ansible_group: "k8s_etcd"
 # etcd version
 etcd_version: "3.5.1"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,6 +6,8 @@
 # "/home/da_user/etcd-certificates".
 etcd_ca_conf_directory: "{{ '~/etcd-certificates' | expanduser }}"
 
+# etcd ansible group
+etcd_ansible_group: "k8s_etcd"
 # etcd version
 etcd_version: "3.5.1"
 # Port where etcd listening for clients

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,7 +6,7 @@
 # "/home/da_user/etcd-certificates".
 etcd_ca_conf_directory: "{{ '~/etcd-certificates' | expanduser }}"
 
-# etcd ansible group
+# etcd Ansible group
 etcd_ansible_group: "k8s_etcd"
 # etcd version
 etcd_version: "3.5.1"

--- a/templates/etc/systemd/system/etcd.service.j2
+++ b/templates/etc/systemd/system/etcd.service.j2
@@ -1,6 +1,6 @@
 #jinja2: trim_blocks:False
 {%- macro cluster_hosts() -%}
-{%- for host in groups['k8s_etcd'] -%}
+{%- for host in groups[etcd_ansible_group] -%}
 {{hostvars[host]['ansible_hostname']}}=https://{{hostvars[host]['ansible_' + etcd_interface].ipv4.address}}:{{etcd_peer_port}}{% if not loop.last %},{% endif %}
 {%- endfor -%} 
 {%- endmacro -%}


### PR DESCRIPTION
The ansible group to which the etcd hosts belong is hardcoded.
Replacing it with the `etcd_ansible_group` variable, set by default to the former hardcoded value `k8s_etcd` allows for more flexible use outside of k8s deployment.