### PR TITLE
srv-discovery support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 ---------
 
+**11.2.0+3.5.4**
+
+- Add `discovery-srv` setting for initial cluster setup (contribution by @cgoubert )
+
 **11.0.0+3.5.1**
 
 - update `etcd` to `v3.5.1`

--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ etcd_settings:
   "logger": "zap" # Specify ‘zap’ for structured logging or ‘capnslog’.
   "log-outputs": "systemd/journal" # Specify 'stdout' or 'stderr' to skip journald logging even when running under systemd
   "enable-v2": "true" # enable v2 API to stay compatible with previous etcd 3.3.x (needed for flannel e.g.)
+  "discovery-srv": "" # Discovery domain to enable DNS SRV discovery, leave empty to disable. If set, will override initial-cluster.
 
 # Certificate authority and certificate files for etcd
 etcd_certificates:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -59,6 +59,7 @@ etcd_settings:
   "logger": "zap" # Specify ‘zap’ for structured logging or ‘capnslog’.
   "log-outputs": "systemd/journal" # Specify 'stdout' or 'stderr' to skip journald logging even when running under systemd
   "enable-v2": "true" # enable v2 API to stay compatible with previous etcd 3.3.x (needed for flannel e.g.)
+  "discovery-srv": "" # Discovery domain to enable DNS SRV discovery, leave empty to disable. If set, will override initial-cluster.
 
 # Certificate authority and certificate files for etcd
 etcd_certificates:

--- a/templates/etc/systemd/system/etcd.service.j2
+++ b/templates/etc/systemd/system/etcd.service.j2
@@ -4,9 +4,10 @@
 {{hostvars[host]['ansible_hostname']}}=https://{{hostvars[host]['ansible_' + etcd_interface].ipv4.address}}:{{etcd_peer_port}}{% if not loop.last %},{% endif %}
 {%- endfor -%} 
 {%- endmacro -%}
-
+{%- if not etcd_settings['discovery-srv'] %}
 {%- set x=etcd_settings.__setitem__('initial-cluster',cluster_hosts()) -%}
-
+{%- set x=etcd_settings.__delitem__('discovery-srv') -%}
+{%- endif %}
 [Unit]
 Description=etcd
 Documentation=https://github.com/coreos

--- a/templates/etc/systemd/system/etcd.service.j2
+++ b/templates/etc/systemd/system/etcd.service.j2
@@ -1,10 +1,10 @@
 #jinja2: trim_blocks:False
+{%- if not etcd_settings['discovery-srv'] %}
 {%- macro cluster_hosts() -%}
 {%- for host in groups[etcd_ansible_group] -%}
 {{hostvars[host]['ansible_hostname']}}=https://{{hostvars[host]['ansible_' + etcd_interface].ipv4.address}}:{{etcd_peer_port}}{% if not loop.last %},{% endif %}
 {%- endfor -%} 
 {%- endmacro -%}
-{%- if not etcd_settings['discovery-srv'] %}
 {%- set x=etcd_settings.__setitem__('initial-cluster',cluster_hosts()) -%}
 {%- set x=etcd_settings.__delitem__('discovery-srv') -%}
 {%- endif %}


### PR DESCRIPTION
Add a variable to set `discovery-srv` command line option to enable etcd [DNS SRV discovery](https://etcd.io/docs/v3.5/op-guide/clustering/#dns-discovery).
If `discovery-srv` is set, skip executing the `cluster_host()` macro or populating `initial-cluster`. If it isn't, former default behavior is preserved.