### PR TITLE
Updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Changelog
 - update `etcd` to `v3.5.4`
 - introduce `etcd_ansible_group` variable to allow setting the Ansible group variable for the etcd hosts. The group was formerly hardcoded to `k8s_etcd'.
 - add `no_log` to certificate copy task to avoid private key leakage
+- add Molecule test
 
 **11.0.0+3.5.1**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Changelog
 **11.1.0+3.5.4**
 
 - update `etcd` to `v3.5.4`
-- introduce `etcd_ansible_group` variable to allow setting the Ansible group variable for the etcd hosts. The group was formerly hardcoded to `k8s_etcd'.
+- introduce `etcd_ansible_group` variable to allow setting the Ansible group variable for the etcd hosts. The group was formerly hardcoded to `k8s_etcd`.
 - add `no_log` to certificate copy task to avoid private key leakage
 - add Molecule test
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Changelog
 - introduce `etcd_ansible_group` variable to allow setting the Ansible group variable for the etcd hosts. The group was formerly hardcoded to `k8s_etcd`.
 - add `no_log` to certificate copy task to avoid private key leakage
 - add Molecule test
+- checksum etcd binaries after download
 
 **11.0.0+3.5.1**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 Changelog
 ---------
 
+**11.1.0+3.5.4**
+
+- update `etcd` to `v3.5.4`
+- introduce `etcd_ansible_group` variable to allow setting the Ansible group variable for the etcd hosts. The group was formerly hardcoded to `k8s_etcd'.
+- add `no_log` to certificate copy task to avoid private key leakage
+
 **11.0.0+3.5.1**
 
 - update `etcd` to `v3.5.1`

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ etcd_ca_conf_directory: "{{ '~/etcd-certificates' | expanduser }}"
 # etcd Ansible group
 etcd_ansible_group: "k8s_etcd"
 # etcd version
-etcd_version: "3.5.1"
+etcd_version: "3.5.4"
 # Port where etcd listening for clients
 etcd_client_port: "2379"
 # Port where etcd is listening for it's peer's

--- a/README.md
+++ b/README.md
@@ -114,6 +114,29 @@ Example Playbook
     - githubixx.etcd
 ```
 
+Testing
+-------
+
+This role has a small test setup that is created using [Molecule](https://github.com/ansible-community/molecule), libvirt (vagrant-libvirt) and QEMU/KVM. Please see my blog post [Testing Ansible roles with Molecule, libvirt (vagrant-libvirt) and QEMU/KVM](https://www.tauceti.blog/posts/testing-ansible-roles-with-molecule-libvirt-vagrant-qemu-kvm/) how to setup. The test configuration is [here](https://github.com/githubixx/ansible-role-etc/tree/master/molecule/kvm).
+
+Afterwards Molecule can be executed:
+
+```bash
+molecule converge -s kvm
+```
+
+This will setup a three virtual machines (VM) with Ubuntu 20.04 and installs an `etcd` cluster. A small verification step is also included:
+
+```bash
+molecule verify -s kvm
+```
+
+To clean up run
+
+```bash
+molecule destroy -s kvm
+```
+
 License
 -------
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,7 +9,7 @@ etcd_ca_conf_directory: "{{ '~/etcd-certificates' | expanduser }}"
 # etcd Ansible group
 etcd_ansible_group: "k8s_etcd"
 # etcd version
-etcd_version: "3.5.1"
+etcd_version: "3.5.4"
 # Port where etcd listening for clients
 etcd_client_port: "2379"
 # Port where etcd is listening for it's peer's

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -3,6 +3,7 @@ galaxy_info:
   description: Installs etcd cluster.
   license: GPLv3
   min_ansible_version: 2.9
+  namespace: githubixx
   platforms:
   - name: Ubuntu
     versions:

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -2,7 +2,7 @@ galaxy_info:
   author: Robert Wimmer
   description: Installs etcd cluster.
   license: GPLv3
-  min_ansible_version: 2.2
+  min_ansible_version: 2.9
   platforms:
   - name: Ubuntu
     versions:

--- a/molecule/kvm/converge.yml
+++ b/molecule/kvm/converge.yml
@@ -1,0 +1,12 @@
+---
+# Copyright (C) 2022 Robert Wimmer
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+- hosts: k8s_etcd
+  remote_user: vagrant
+  become: true
+  gather_facts: true
+  tasks:
+    - name: Include etcd role
+      include_role:
+        name: githubixx.etcd

--- a/molecule/kvm/group_vars/all.yml
+++ b/molecule/kvm/group_vars/all.yml
@@ -1,4 +1,7 @@
 ---
+# Copyright (C) 2022 Robert Wimmer
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 etcd_ca_conf_directory: "/tmp/githubixx.etcd"
 etcd_conf_dir: "/etc/etcd"
 etcd_interface: "eth1"
@@ -7,8 +10,4 @@ k8s_ca_conf_directory: "/tmp/githubixx.etcd"
 k8s_ca_conf_directory_perm: "0775"
 k8s_ca_file_perm: "0666"
 k8s_interface: "eth1"
-
-#k8s_ca_controller_nodes_group: k8s_controller
-#k8s_ca_etcd_nodes_group: k8s_etcd
-#k8s_ca_worker_nodes_group: k8s_worker
 

--- a/molecule/kvm/group_vars/all.yml
+++ b/molecule/kvm/group_vars/all.yml
@@ -1,0 +1,14 @@
+---
+etcd_ca_conf_directory: "/tmp/githubixx.etcd"
+etcd_conf_dir: "/etc/etcd"
+etcd_interface: "eth1"
+
+k8s_ca_conf_directory: "/tmp/githubixx.etcd"
+k8s_ca_conf_directory_perm: "0775"
+k8s_ca_file_perm: "0666"
+k8s_interface: "eth1"
+
+#k8s_ca_controller_nodes_group: k8s_controller
+#k8s_ca_etcd_nodes_group: k8s_etcd
+#k8s_ca_worker_nodes_group: k8s_worker
+

--- a/molecule/kvm/molecule.yml
+++ b/molecule/kvm/molecule.yml
@@ -1,0 +1,68 @@
+---
+# Copyright (C) 2022 Robert Wimmer
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+dependency:
+  name: galaxy
+
+driver:
+  name: vagrant
+  provider:
+    name: libvirt
+    type: libvirt
+    options:
+      memory: 192
+      cpus: 2
+
+platforms:
+  - name: test-etcd1-ubuntu2004
+    box: generic/ubuntu2004
+    groups:
+      - k8s_controller
+      - k8s_worker
+      - k8s_etcd
+    interfaces:
+      - auto_config: true
+        network_name: private_network
+        type: static
+        ip: 192.168.10.10
+  - name: test-etcd2-ubuntu2004
+    box: generic/ubuntu2004
+    groups:
+      - k8s_controller
+      - k8s_worker
+      - k8s_etcd
+    interfaces:
+      - auto_config: true
+        network_name: private_network
+        type: static
+        ip: 192.168.10.20
+  - name: test-etcd3-ubuntu2004
+    box: generic/ubuntu2004
+    groups:
+      - k8s_controller
+      - k8s_worker
+      - k8s_etcd
+    interfaces:
+      - auto_config: true
+        network_name: private_network
+        type: static
+        ip: 192.168.10.30
+
+provisioner:
+  name: ansible
+  connection_options:
+    ansible_ssh_user: vagrant
+    ansible_become: true
+  log: true
+  lint: yamllint . && flake8 && ansible-lint
+
+scenario:
+  name: kvm
+  test_sequence:
+    - prepare
+    - converge
+
+verifier:
+  name: ansible
+  enabled: true

--- a/molecule/kvm/prepare.yml
+++ b/molecule/kvm/prepare.yml
@@ -1,0 +1,34 @@
+---
+# Copyright (C) 2022 Robert Wimmer
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+- name: Setup cfssl
+  hosts: localhost
+  connection: local
+  become: true
+  gather_facts: false
+  tasks:
+    - name: Include cfssl role
+      include_role:
+        name: githubixx.cfssl
+
+- name: Update cache
+  hosts: k8s_etcd
+  remote_user: vagrant
+  become: true
+  gather_facts: true
+  tasks:
+    - name: Update APT package cache
+      apt:
+        update_cache: true
+        cache_valid_time: 3600
+
+- name: Setup TLS certificates for etcd
+  hosts: localhost
+  connection: local
+  become: true
+  gather_facts: false
+  tasks:
+    - name: Include kubernetes-ca role to generate TLS certificate files for etcd
+      include_role:
+        name: githubixx.kubernetes-ca

--- a/molecule/kvm/verify.yml
+++ b/molecule/kvm/verify.yml
@@ -1,0 +1,90 @@
+---
+# Copyright (C) 2022 Robert Wimmer
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+- name: Verify setup
+  hosts: all
+  vars:
+    etcdctl_version: "3.5"
+    etcdctl_endpoint_health: "is healthy"
+    etcdctl_put: "testvalue"
+  tasks:
+    - name: Execute etcdctl version to capture output
+      command: etcdctl version
+      register: etcdctl_version_output
+      changed_when: false
+
+    - name: Ensure etcdctl version output contains correct version string
+      assert:
+        that:
+          - "etcdctl_version in etcdctl_version_output.stdout"
+
+    - name: Check etcd endpoint health
+      shell: >
+        set -o errexit; \
+        set -o pipefail; \
+        ETCDCTL_API=3 etcdctl endpoint health \
+        --endpoints=https://localhost:2379 \
+        --cacert={{ etcd_conf_dir }}/ca-etcd.pem \
+        --cert={{ etcd_conf_dir }}/cert-etcd-server.pem \
+        --key={{ etcd_conf_dir }}/cert-etcd-server-key.pem
+      register: etcdctl_endpoint_health_output
+      changed_when: false
+      args:
+        executable: "/bin/bash"
+
+    - name: Assert etcd endpoint health
+      assert:
+        that:
+          - "etcdctl_endpoint_health in etcdctl_endpoint_health_output.stdout"
+
+    - name: Put test value into ectd
+      shell: >
+        set -o errexit; \
+        set -o pipefail; \
+        ETCDCTL_API=3 etcdctl put testkey {{ etcdctl_put }} \
+        --endpoints=https://localhost:2379 \
+        --cacert={{ etcd_conf_dir }}/ca-etcd.pem \
+        --cert={{ etcd_conf_dir }}/cert-etcd-server.pem \
+        --key={{ etcd_conf_dir }}/cert-etcd-server-key.pem
+      register: etcdctl_put_output
+      changed_when: false
+      run_once: true
+      delegate_to: "{{ groups['k8s_etcd'][0] }}"
+      args:
+        executable: "/bin/bash"
+
+    - name: Assert etcdctl put
+      assert:
+        that:
+          - "'OK' in etcdctl_put_output.stdout"
+      run_once: true
+      delegate_to: "{{ groups['k8s_etcd'][0] }}"
+
+    - name: Get test value from ectd
+      shell: >
+        set -o errexit; \
+        set -o pipefail; \
+        ETCDCTL_API=3 etcdctl get testkey \
+        --endpoints=https://localhost:2379 \
+        --cacert={{ etcd_conf_dir }}/ca-etcd.pem \
+        --cert={{ etcd_conf_dir }}/cert-etcd-server.pem \
+        --key={{ etcd_conf_dir }}/cert-etcd-server-key.pem
+      register: etcdctl_get_output
+      changed_when: false
+      run_once: true
+      delegate_to: "{{ groups['k8s_etcd'][1] }}"
+      args:
+        executable: "/bin/bash"
+
+    - name: Output testvalue
+      debug:
+        var: etcdctl_put
+
+    - name: Assert etcdctl get
+      assert:
+        that:
+          - "'{{ etcdctl_put }}' in etcdctl_get_output.stdout"
+      run_once: true
+      delegate_to: "{{ groups['k8s_etcd'][1] }}"
+

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -48,6 +48,7 @@
   get_url:
     url: "https://github.com/coreos/etcd/releases/download/v{{ etcd_version }}/etcd-v{{ etcd_version }}-linux-{{ etcd_architecture }}.tar.gz"
     dest: "{{ etcd_download_dir }}/etcd-v{{ etcd_version }}-linux-{{ etcd_architecture }}.tar.gz"
+    checksum: "sha256:https://github.com/coreos/etcd/releases/download/v{{ etcd_version }}/SHA256SUMS"
     mode: 0755
   tags:
     - etcd


### PR DESCRIPTION
- update `etcd` to `v3.5.4`
- introduce `etcd_ansible_group` variable to allow setting the Ansible group variable for the etcd hosts. The group was formerly hardcoded to `k8s_etcd`.
- add `no_log` to certificate copy task to avoid private key leakage
- add Molecule test
- checksum etcd binaries after download