### PR TITLE
11.3.0+3.5.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 ---------
 
+**11.3.0+3.5.4**
+
+- This is mainly a "cosmetic" change. Makes Ansible's linter `ansible-lint` happy, fixes a few typos and use FQDN module names
+
 **11.2.0+3.5.4**
 
 - Add `discovery-srv` setting for initial cluster setup (contribution by @cgoubert )
@@ -34,7 +38,7 @@ Changelog
 
 - changed some default values for `etcd_settings`. `(cert|key)-file` and `peer-(cert|key)-file` now uses different certificates:
 
-```
+```yaml
 "cert-file": "{{etcd_conf_dir}}/cert-etcd-server.pem"
 "key-file": "{{etcd_conf_dir}}/cert-etcd-server-key.pem"
 "peer-cert-file": "{{etcd_conf_dir}}/cert-etcd-peer.pem"
@@ -51,7 +55,7 @@ Therefore `etcd_certificates` list was also adjusted accordingly.
 
 Removed old tags below as the format is not supported by Ansible Galaxy and also not compatible with semver.org:
 
-```
+```plain
 r1.0.0_v3.2.8
 r2.0.0_v3.2.13
 r3.0.0_v3.2.13
@@ -114,7 +118,7 @@ r6.0.1_v3.2.24
 
 **r3.1.0_v3.2.13**
 
-- move some variables into etcd_settings dictionary. As they're not needed outside of the etcd role there is no need to keep them seperate.
+- move some variables into etcd_settings dictionary. As they're not needed outside of the etcd role there is no need to keep them separate.
 
 **r3.0.0_v3.2.13**
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This role requires that you already created some certificates for `etcd` (see [K
 Role Variables
 --------------
 
-```
+```yaml
 # The directory from where to copy the etcd certificates. By default this
 # will expand to user's LOCAL $HOME (the user that run's "ansible-playbook ..."
 # plus "/etcd-certificates". That means if the user's $HOME directory is e.g.
@@ -43,12 +43,12 @@ etcd_client_port: "2379"
 etcd_peer_port: "2380"
 # Interface to bind etcd ports to
 etcd_interface: "tap0"
-# Directroy for etcd configuration
+# Directory for etcd configuration
 etcd_conf_dir: "/etc/etcd"
 # Directory to store downloaded etcd archive
 # Should not be deleted to avoid downloading over and over again
 etcd_download_dir: "/opt/etcd"
-# Directroy to store etcd binaries
+# Directory to store etcd binaries
 etcd_bin_dir: "/usr/local/bin"
 # etcd data directory (etcd database files so to say)
 etcd_data_dir: "/var/lib/etcd"
@@ -75,7 +75,7 @@ etcd_settings:
   "initial-cluster-token": "etcd-cluster-0" # Initial cluster token for the etcd cluster during bootstrap.
   "initial-cluster-state": "new" # Initial cluster state ('new' or 'existing')
   "data-dir": "{{etcd_data_dir}}" # etcd data directory (etcd database files so to say)
-  "wal-dir": "" # Dedicated wal directory ("" means no seperated WAL directory)
+  "wal-dir": "" # Dedicated wal directory ("" means no separated WAL directory)
   "auto-compaction-retention": "0" # Auto compaction retention in hour. 0 means disable auto compaction.
   "snapshot-count": "100000" # Number of committed transactions to trigger a snapshot to disk
   "heartbeat-interval": "100" # Time (in milliseconds) of a heartbeat interval
@@ -98,9 +98,9 @@ etcd_certificates:
   - cert-etcd-server-key.pem  # server TLS key file
 ```
 
-The `etcd` default settings defined in `etcd_settings` can be overriden by defining a variable called `etcd_settings_user`. You can also add additional settings by using this variable. E.g. to override the default value for `log-output` seting and add a new setting like `grpc-keepalive-min-time` add the following settings to `group_vars/k8s.yml`:
+The `etcd` default settings defined in `etcd_settings` can be overridden by defining a variable called `etcd_settings_user`. You can also add additional settings by using this variable. E.g. to override the default value for `log-output` setting and add a new setting like `grpc-keepalive-min-time` add the following settings to `group_vars/k8s.yml`:
 
-```
+```yaml
 etcd_settings_user:
   "log-output": "stdout"
   "grpc-keepalive-min-time": "10s"
@@ -109,7 +109,7 @@ etcd_settings_user:
 Example Playbook
 ----------------
 
-```
+```yaml
 - hosts: k8s_etcd
   roles:
     - githubixx.etcd

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -32,22 +32,22 @@ etcd_architecture: "amd64"
 etcd_allow_unsupported_archs: false
 
 etcd_settings:
-  "name": "{{ansible_hostname}}"
-  "cert-file": "{{etcd_conf_dir}}/cert-etcd-server.pem"
-  "key-file": "{{etcd_conf_dir}}/cert-etcd-server-key.pem"
-  "trusted-ca-file": "{{etcd_conf_dir}}/ca-etcd.pem"
-  "peer-cert-file": "{{etcd_conf_dir}}/cert-etcd-peer.pem"
-  "peer-key-file": "{{etcd_conf_dir}}/cert-etcd-peer-key.pem"
-  "peer-trusted-ca-file": "{{etcd_conf_dir}}/ca-etcd.pem"
+  "name": "{{ ansible_hostname }}"
+  "cert-file": "{{ etcd_conf_dir }}/cert-etcd-server.pem"
+  "key-file": "{{ etcd_conf_dir }}/cert-etcd-server-key.pem"
+  "trusted-ca-file": "{{ etcd_conf_dir }}/ca-etcd.pem"
+  "peer-cert-file": "{{ etcd_conf_dir }}/cert-etcd-peer.pem"
+  "peer-key-file": "{{ etcd_conf_dir }}/cert-etcd-peer-key.pem"
+  "peer-trusted-ca-file": "{{ etcd_conf_dir }}/ca-etcd.pem"
   "peer-client-cert-auth": "true" # # Enable peer client cert authentication
   "client-cert-auth": "true" # Enable client cert authentication
-  "advertise-client-urls": "{{'https://' + hostvars[inventory_hostname]['ansible_' + etcd_interface].ipv4.address + ':' + etcd_client_port}}"
-  "initial-advertise-peer-urls": "{{'https://' + hostvars[inventory_hostname]['ansible_' + etcd_interface].ipv4.address + ':' + etcd_peer_port}}"
-  "listen-peer-urls": "{{'https://' + hostvars[inventory_hostname]['ansible_' + etcd_interface].ipv4.address + ':' + etcd_peer_port}}"
-  "listen-client-urls": "{{'https://' + hostvars[inventory_hostname]['ansible_' + etcd_interface].ipv4.address + ':' + etcd_client_port + ',https://127.0.0.1:' + etcd_client_port}}"
+  "advertise-client-urls": "{{ 'https://' + hostvars[inventory_hostname]['ansible_' + etcd_interface].ipv4.address + ':' + etcd_client_port }}"
+  "initial-advertise-peer-urls": "{{ 'https://' + hostvars[inventory_hostname]['ansible_' + etcd_interface].ipv4.address + ':' + etcd_peer_port }}"
+  "listen-peer-urls": "{{ 'https://' + hostvars[inventory_hostname]['ansible_' + etcd_interface].ipv4.address + ':' + etcd_peer_port }}"
+  "listen-client-urls": "{{ 'https://' + hostvars[inventory_hostname]['ansible_' + etcd_interface].ipv4.address + ':' + etcd_client_port + ',https://127.0.0.1:' + etcd_client_port }}"
   "initial-cluster-token": "etcd-cluster-0" # Initial cluster token for the etcd cluster during bootstrap.
   "initial-cluster-state": "new" # Initial cluster state ('new' or 'existing')
-  "data-dir": "{{etcd_data_dir}}" # etcd data directory (etcd database files so to say)
+  "data-dir": "{{ etcd_data_dir }}" # etcd data directory (etcd database files so to say)
   "wal-dir": "" # Dedicated wal directory ("" means no separated WAL directory)
   "auto-compaction-retention": "0" # Auto compaction retention in hour. 0 means disable auto compaction.
   "snapshot-count": "100000" # Number of committed transactions to trigger a snapshot to disk

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,4 +1,4 @@
 ---
 - name: reload systemd
-  systemd:
-    daemon_reload: yes
+  ansible.builtin.systemd:
+    daemon_reload: true

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -3,12 +3,13 @@ galaxy_info:
   description: Installs etcd cluster.
   license: GPLv3
   min_ansible_version: 2.9
+  role_name: etcd
   namespace: githubixx
   platforms:
-  - name: Ubuntu
-    versions:
-    - bionic
-    - focal
+    - name: Ubuntu
+      versions:
+        - bionic
+        - focal
   galaxy_tags:
     - etcd
     - ha

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,30 +1,30 @@
 ---
 - name: Gather instance facts
-  setup:
+  ansible.builtin.setup:
 
 - name: Create etcd config directory
-  file:
+  ansible.builtin.file:
     path: "{{ etcd_conf_dir }}"
     state: directory
   tags:
     - etcd
 
 - name: Create etcd download directory
-  file:
+  ansible.builtin.file:
     path: "{{ etcd_download_dir }}"
     state: directory
   tags:
     - etcd
 
 - name: Create etcd bin directory
-  file:
+  ansible.builtin.file:
     path: "{{ etcd_bin_dir }}"
     state: directory
   tags:
     - etcd
 
 - name: Create etcd data directory
-  file:
+  ansible.builtin.file:
     path: "{{ etcd_data_dir }}"
     state: directory
     mode: 0700
@@ -32,7 +32,7 @@
     - etcd
 
 - name: Copy certificates
-  copy:
+  ansible.builtin.copy:
     src: "{{ etcd_ca_conf_directory }}/{{ item }}"
     dest: "{{ etcd_conf_dir }}/{{ item }}"
     mode: 0640
@@ -45,7 +45,7 @@
     - etcd
 
 - name: Downloading official etcd release
-  get_url:
+  ansible.builtin.get_url:
     url: "https://github.com/coreos/etcd/releases/download/v{{ etcd_version }}/etcd-v{{ etcd_version }}-linux-{{ etcd_architecture }}.tar.gz"
     dest: "{{ etcd_download_dir }}/etcd-v{{ etcd_version }}-linux-{{ etcd_architecture }}.tar.gz"
     checksum: "sha256:https://github.com/coreos/etcd/releases/download/v{{ etcd_version }}/SHA256SUMS"
@@ -55,10 +55,10 @@
     - skip_ansible_lint
 
 - name: Unzip downloaded file
-  unarchive:
+  ansible.builtin.unarchive:
     src: "{{ etcd_download_dir }}/etcd-v{{ etcd_version }}-linux-{{ etcd_architecture }}.tar.gz"
     dest: "{{ etcd_download_dir }}/"
-    remote_src: yes
+    remote_src: true
     owner: "root"
     group: "root"
     creates: "{{ etcd_download_dir }}/etcd-v{{ etcd_version }}-linux-{{ etcd_architecture }}/etcd"
@@ -66,13 +66,13 @@
     - etcd
 
 - name: Copy etcd binaries to destination directory
-  copy:
+  ansible.builtin.copy:
     src: "{{ etcd_download_dir }}/etcd-v{{ etcd_version }}-linux-{{ etcd_architecture }}/{{ item }}"
     dest: "{{ etcd_bin_dir }}/{{ item }}"
     mode: 0755
     owner: root
     group: root
-    remote_src: yes
+    remote_src: true
   with_items:
     - etcd
     - etcdctl
@@ -80,14 +80,14 @@
     - etcd
 
 - name: Combine etcd_settings and etcd_settings_user (if defined)
-  set_fact:
+  ansible.builtin.set_fact:
     etcd_settings: "{{ etcd_settings | combine(etcd_settings_user|default({})) }}"
   tags:
     - etcd
     - etcd-systemd
 
 - name: Create systemd unit file
-  template:
+  ansible.builtin.template:
     src: etc/systemd/system/etcd.service.j2
     dest: /etc/systemd/system/etcd.service
     owner: root
@@ -99,12 +99,13 @@
     - etcd
     - etcd-systemd
 
-- meta: flush_handlers
+- name: Flush handlers
+  ansible.builtin.meta: flush_handlers
 
 - name: Enable and start etcd
-  service:
+  ansible.builtin.service:
     name: etcd
-    enabled: yes
+    enabled: true
     state: started
   tags:
     - etcd


### PR DESCRIPTION
This is mainly a "cosmetic" change. Makes Ansible's linter `ansible-lint` happy, fixes a few typos and use FQDN module names