### PR TITLE
12.0.0+3.5.4

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,39 @@
+---
+# This workflow requires a GALAXY_API_KEY secret present in the GitHub
+# repository or organization.
+#
+# See: https://github.com/marketplace/actions/publish-ansible-role-to-galaxy
+# See: https://github.com/ansible/galaxy/issues/46
+
+name: Release
+on:
+  push:
+    tags:
+      - '*'
+
+defaults:
+  run:
+    working-directory: 'githubixx.etcd'
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the codebase.
+        uses: actions/checkout@v2
+        with:
+          path: 'githubixx.etcd'
+
+      - name: Set up Python 3.
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
+
+      - name: Install Ansible.
+        run: pip3 install ansible-core
+
+      - name: Trigger a new import on Galaxy.
+        run: >-
+          ansible-galaxy role import --api-key ${{ secrets.GALAXY_API_KEY }}
+          $(echo ${{ github.repository }} | cut -d/ -f1) $(echo ${{ github.repository }} | cut -d/ -f2)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Changelog
 
 - introduce new variables: `etcd_conf_dir_mode`, `etcd_download_dir_mode` and `etcd_bin_dir_mode` (see README)
 - fix various `ansible-lint` issues
+- add Github release action to push new release to Ansible Galaxy
 
 **11.3.0+3.5.4**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changelog
 ---------
 
+**12.0.0+3.5.4**
+
+- introduce new variables: `etcd_conf_dir_mode`, `etcd_download_dir_mode` and `etcd_bin_dir_mode` (see README)
+- fix various `ansible-lint` issues
+
 **11.3.0+3.5.4**
 
 - This is mainly a "cosmetic" change. Makes Ansible's linter `ansible-lint` happy, fixes a few typos and use FQDN module names

--- a/README.md
+++ b/README.md
@@ -45,11 +45,20 @@ etcd_peer_port: "2380"
 etcd_interface: "tap0"
 # Directory for etcd configuration
 etcd_conf_dir: "/etc/etcd"
+# Permissions for directory for etcd configuration
+etcd_conf_dir_mode: 0755
 # Directory to store downloaded etcd archive
 # Should not be deleted to avoid downloading over and over again
 etcd_download_dir: "/opt/etcd"
+# Permissions for directory to store downloaded etcd archive
+etcd_download_dir_mode: 0755
 # Directory to store etcd binaries
 etcd_bin_dir: "/usr/local/bin"
+# Permissions for irectory to store etcd binaries
+# IMPORTANT: If you use the default value for "etcd_bin_dir" which is
+# "/usr/local/bin" make sure that the permissions are correct as this
+# directory exists on every Linux filesystem and is very important!
+etcd_bin_dir_mode: 0755
 # etcd data directory (etcd database files so to say)
 etcd_data_dir: "/var/lib/etcd"
 # Architecture to download and install

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -27,7 +27,7 @@ etcd_download_dir: "/opt/etcd"
 etcd_download_dir_mode: 0755
 # Directory to store etcd binaries
 etcd_bin_dir: "/usr/local/bin"
-# Permissions for irectory to store etcd binaries
+# Permissions for directory to store etcd binaries
 # IMPORTANT: If you use the default value for "etcd_bin_dir" which is
 # "/usr/local/bin" make sure that the permissions are correct as this
 # directory exists on every Linux filesystem and is very important!

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -18,11 +18,20 @@ etcd_peer_port: "2380"
 etcd_interface: "tap0"
 # Directory for etcd configuration
 etcd_conf_dir: "/etc/etcd"
+# Permissions for directory for etcd configuration
+etcd_conf_dir_mode: 0755
 # Directory to store downloaded etcd archive
 # Should not be deleted to avoid downloading over and over again
 etcd_download_dir: "/opt/etcd"
+# Permissions for directory to store downloaded etcd archive
+etcd_download_dir_mode: 0755
 # Directory to store etcd binaries
 etcd_bin_dir: "/usr/local/bin"
+# Permissions for irectory to store etcd binaries
+# IMPORTANT: If you use the default value for "etcd_bin_dir" which is
+# "/usr/local/bin" make sure that the permissions are correct as this
+# directory exists on every Linux filesystem and is very important!
+etcd_bin_dir_mode: 0755
 # etcd data directory (etcd database files so to say)
 etcd_data_dir: "/var/lib/etcd"
 # Architecture to download and install

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,4 +1,4 @@
 ---
-- name: reload systemd
+- name: Reload systemd
   ansible.builtin.systemd:
     daemon_reload: true

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,15 +1,16 @@
+---
 galaxy_info:
   author: Robert Wimmer
   description: Installs etcd cluster.
   license: GPLv3
-  min_ansible_version: 2.9
+  min_ansible_version: "2.9"
   role_name: etcd
   namespace: githubixx
   platforms:
     - name: Ubuntu
       versions:
-        - bionic
-        - focal
+        - "bionic"
+        - "focal"
   galaxy_tags:
     - etcd
     - ha

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -97,7 +97,7 @@
     group: root
     mode: 0644
   notify:
-    - reload systemd
+    - Reload systemd
   tags:
     - etcd
     - etcd-systemd

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -81,7 +81,7 @@
 
 - name: Combine etcd_settings and etcd_settings_user (if defined)
   ansible.builtin.set_fact:
-    etcd_settings: "{{ etcd_settings | combine(etcd_settings_user|default({})) }}"
+    etcd_settings: "{{ etcd_settings | combine(etcd_settings_user | default({})) }}"
   tags:
     - etcd
     - etcd-systemd

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,6 +6,7 @@
   ansible.builtin.file:
     path: "{{ etcd_conf_dir }}"
     state: directory
+    mode: "{{ etcd_conf_dir_mode }}"
   tags:
     - etcd
 
@@ -13,6 +14,7 @@
   ansible.builtin.file:
     path: "{{ etcd_download_dir }}"
     state: directory
+    mode: "{{ etcd_download_dir_mode }}"
   tags:
     - etcd
 
@@ -20,6 +22,7 @@
   ansible.builtin.file:
     path: "{{ etcd_bin_dir }}"
     state: directory
+    mode: "{{ etcd_bin_dir_mode }}"
   tags:
     - etcd
 

--- a/templates/etc/systemd/system/etcd.service.j2
+++ b/templates/etc/systemd/system/etcd.service.j2
@@ -10,7 +10,7 @@
 {%- endif %}
 [Unit]
 Description=etcd
-Documentation=https://github.com/coreos
+Documentation=https://github.com/etcd-io/etcd/
 
 [Service]
 {% if etcd_allow_unsupported_archs %}


### PR DESCRIPTION
- introduce new variables: `etcd_conf_dir_mode`, `etcd_download_dir_mode` and `etcd_bin_dir_mode` (see README)
- fix various `ansible-lint` issues
- add Github release action to push new release to Ansible Galaxy