### PR TITLE
Download etcd binaries from custom URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ etcd_architecture: "amd64"
 # Only change this if the architecture you are using is unsupported (for example: arm64)
 # For more information, see this: https://github.com/etcd-io/website/blob/master/content/docs/v3.4/op-guide/supported-platform.md
 etcd_allow_unsupported_archs: false
+# Download etcd archive from a custom URL, if set to true (needs etcd_custom_url to be set, which is undefined)
+etcd_custom_download: false
 
 etcd_settings:
   "name": "{{ansible_hostname}}"

--- a/README.md
+++ b/README.md
@@ -66,10 +66,18 @@ etcd_architecture: "amd64"
 # Only change this if the architecture you are using is unsupported (for example: arm64)
 # For more information, see this: https://github.com/etcd-io/website/blob/master/content/docs/v3.4/op-guide/supported-platform.md
 etcd_allow_unsupported_archs: false
-# Download etcd archive from a custom URL, if set to true (needs etcd_custom_url to be set, which is undefined)
-etcd_custom_download: false
-# etcd_custom_url is undefined and can be set to a custom URL to download the tarball
-# etcd_custom_checksum is undefined and if a checksum is passed to this parameter, the digest of the destination file will be calculated after it is downloaded to ensure its integrity and verify that the transfer completed successfully. Read more here: https://docs.ansible.com/ansible/latest/collections/ansible/builtin/get_url_module.html 
+# By default etcd tarball gets downloaded from official
+# etcd repository. This can be changed to some custom
+# URL if needed. For more information which protocols
+# can be used see:
+# https://docs.ansible.com/ansible/latest/collections/ansible/builtin/get_url_module.html
+# It's only important to keep the filename naming schema:
+# "etcd-v{{ etcd_version }}-linux-{{ etcd_architecture }}.tar.gz"
+etcd_download_url: "https://github.com/etcd-io/etcd/releases/download/v{{ etcd_version }}/etcd-v{{ etcd_version }}-linux-{{ etcd_architecture }}.tar.gz"
+# By default the SHA256SUMS file is used to verify the
+# checksum of the tarball archive. This can also be
+# changed to your needs.
+etcd_download_url_checksum: "sha256:https://github.com/coreos/etcd/releases/download/v{{ etcd_version }}/SHA256SUMS"
 
 etcd_settings:
   "name": "{{ansible_hostname}}"

--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ etcd_architecture: "amd64"
 etcd_allow_unsupported_archs: false
 # Download etcd archive from a custom URL, if set to true (needs etcd_custom_url to be set, which is undefined)
 etcd_custom_download: false
+# etcd_custom_url is undefined and can be set to a custom URL to download the tarball
+# etcd_custom_checksum is undefined and if a checksum is passed to this parameter, the digest of the destination file will be calculated after it is downloaded to ensure its integrity and verify that the transfer completed successfully. Read more here: https://docs.ansible.com/ansible/latest/collections/ansible/builtin/get_url_module.html 
 
 etcd_settings:
   "name": "{{ansible_hostname}}"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -39,8 +39,18 @@ etcd_architecture: "amd64"
 # Only change this if the architecture you are using is unsupported (for example: arm64)
 # For more information, see this: https://github.com/etcd-io/website/blob/master/content/docs/v3.4/op-guide/supported-platform.md
 etcd_allow_unsupported_archs: false
-# Download etcd archive from a custom URL, if set to true (needs etcd_custom_url to be set, which is undefined)
-etcd_custom_download: false
+# By default etcd tarball gets downloaded from official
+# etcd repository. This can be changed to some custom
+# URL if needed. For more information which protocols
+# can be used see:
+# https://docs.ansible.com/ansible/latest/collections/ansible/builtin/get_url_module.html
+# It's only important to keep the filename naming schema:
+# "etcd-v{{ etcd_version }}-linux-{{ etcd_architecture }}.tar.gz"
+etcd_download_url: "https://github.com/etcd-io/etcd/releases/download/v{{ etcd_version }}/etcd-v{{ etcd_version }}-linux-{{ etcd_architecture }}.tar.gz"
+# By default the SHA256SUMS file is used to verify the
+# checksum of the tarball archive. This can also be
+# changed to your needs.
+etcd_download_url_checksum: "sha256:https://github.com/coreos/etcd/releases/download/v{{ etcd_version }}/SHA256SUMS"
 
 etcd_settings:
   "name": "{{ ansible_hostname }}"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -39,6 +39,8 @@ etcd_architecture: "amd64"
 # Only change this if the architecture you are using is unsupported (for example: arm64)
 # For more information, see this: https://github.com/etcd-io/website/blob/master/content/docs/v3.4/op-guide/supported-platform.md
 etcd_allow_unsupported_archs: false
+# Download etcd archive from a custom URL, if set to true (needs etcd_custom_url to be set, which is undefined)
+etcd_custom_download: false
 
 etcd_settings:
   "name": "{{ ansible_hostname }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -49,9 +49,9 @@
 
 - name: Downloading official etcd release
   ansible.builtin.get_url:
-    url: "https://github.com/coreos/etcd/releases/download/v{{ etcd_version }}/etcd-v{{ etcd_version }}-linux-{{ etcd_architecture }}.tar.gz"
+    url: "{{ etcd_download_url }}"
     dest: "{{ etcd_download_dir }}/etcd-v{{ etcd_version }}-linux-{{ etcd_architecture }}.tar.gz"
-    checksum: "sha256:https://github.com/coreos/etcd/releases/download/v{{ etcd_version }}/SHA256SUMS"
+    checksum: "{{ etcd_download_url_checksum }}"
     mode: 0755
   tags:
     - etcd

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -56,6 +56,16 @@
   tags:
     - etcd
     - skip_ansible_lint
+  when: not etcd_custom_download | bool
+
+- name: Downloading etcd from custom URL 
+  ansible.builtin.get_url:
+    url: "{{ etcd_custom_url }}"
+    dest: "{{ etcd_download_dir }}/etcd-v{{ etcd_version }}-linux-{{ etcd_architecture }}.tar.gz"
+    mode: 0755
+  tags:
+    - etcd
+  when: etcd_custom_download | bool
 
 - name: Unzip downloaded file
   ansible.builtin.unarchive:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -62,6 +62,7 @@
   ansible.builtin.get_url:
     url: "{{ etcd_custom_url }}"
     dest: "{{ etcd_download_dir }}/etcd-v{{ etcd_version }}-linux-{{ etcd_architecture }}.tar.gz"
+    checksum: "{{ etcd_custom_checksum | default(omit) }}"
     mode: 0755
   tags:
     - etcd

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -56,17 +56,6 @@
   tags:
     - etcd
     - skip_ansible_lint
-  when: not etcd_custom_download | bool
-
-- name: Downloading etcd from custom URL 
-  ansible.builtin.get_url:
-    url: "{{ etcd_custom_url }}"
-    dest: "{{ etcd_download_dir }}/etcd-v{{ etcd_version }}-linux-{{ etcd_architecture }}.tar.gz"
-    checksum: "{{ etcd_custom_checksum | default(omit) }}"
-    mode: 0755
-  tags:
-    - etcd
-  when: etcd_custom_download | bool
 
 - name: Unzip downloaded file
   ansible.builtin.unarchive:


### PR DESCRIPTION
Changes:
- Added task to download tarball from custom URL
- Added variable `etcd_custom_download` to defaults
- Added required information to use this option in README.md

Fixes #28