### PR TITLE
Allow to specify systemd unit name

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -147,6 +147,9 @@ etcd_download_url: "https://github.com/etcd-io/etcd/releases/download/v{{ etcd_v
 # changed to your needs.
 etcd_download_url_checksum: "sha256:https://github.com/coreos/etcd/releases/download/v{{ etcd_version }}/SHA256SUMS"
 
+# Name for etcd systemd unit
+etcd_service_name: "etcd"
+
 # Options for [Service] section. For more information see:
 # https://www.freedesktop.org/software/systemd/man/systemd.service.html#Options
 # The options below "Type=notify" are mostly security/sandbox related settings

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -139,7 +139,7 @@
 - name: Create systemd unit file
   ansible.builtin.template:
     src: etc/systemd/system/etcd.service.j2
-    dest: /etc/systemd/system/etcd.service
+    dest: "/etc/systemd/system/{{ etcd_service_name }}.service"
     owner: "root"
     group: "root"
     mode: "0644"
@@ -154,7 +154,7 @@
 
 - name: Enable and start etcd
   ansible.builtin.service:
-    name: etcd
+    name: "{{ etcd_service_name }}"
     enabled: true
     state: started
   tags:


### PR DESCRIPTION
This PR adds an oportunity to specfy systemd unit name

It is very useful when you want to deploy multiple clusters on the same server