### PR TITLE
Correct error for ansible galaxy install.

### DIFF
--- a/.ansible/roles/githubixx.etcd
+++ b/.ansible/roles/githubixx.etcd
@@ -1,1 +1,0 @@
-/opt/scripts/ansible/roles/githubixx.etcd


### PR DESCRIPTION
Fix error of installation from ansible-galaxy for versions
* 14.0.0+3.5.22:
```bash
# ansible-galaxy install --force githubixx.etcd,14.0.0+3.5.22 -vvv
ansible-galaxy [core 2.18.6]
  config file = /ansible/ansible.cfg
  configured module search path = ['/ansible/.ansible/collections/ansible_collections/debops/debops/plugins/modules']
  ansible python module location = /usr/local/lib/python3.13/site-packages/ansible
  ansible collection location = /ansible/.ansible/collections
  executable location = /usr/local/bin/ansible-galaxy
  python version = 3.13.5 (main, Jun 12 2025, 22:38:58) [GCC 14.2.0] (/usr/local/bin/python)
  jinja version = 3.1.6
  libyaml = True
Using /ansible/ansible.cfg as config file
Starting galaxy role install process
Processing role githubixx.etcd 
- changing role githubixx.etcd from 13.2.1+3.5.17 to 14.0.0+3.5.22
Opened /root/.ansible/galaxy_token
- downloading role 'etcd', owned by githubixx
- downloading role from https://github.com/githubixx/ansible-role-etcd/archive/14.0.0+3.5.22.tar.gz
- extracting githubixx.etcd to /ansible/.ansible/roles/githubixx.etcd
[WARNING]: - githubixx.etcd was NOT installed successfully: Invalid linkname for tarfile member: path /opt/scripts/ansible/roles/githubixx.etcd is not a subpath of the role
/ansible/ansible-role-etcd-14.0.0-3.5.22
ERROR! - you can use --ignore-errors to skip failed roles and finish processing the list.
```
* 14.0.1+3.5.22:
```
# ansible-galaxy install --force githubixx.etcd,14.0.1+3.5.22 -vvv
ansible-galaxy [core 2.18.6]
  config file = /ansible/ansible.cfg
  configured module search path = ['/ansible/.ansible/collections/ansible_collections/debops/debops/plugins/modules']
  ansible python module location = /usr/local/lib/python3.13/site-packages/ansible
  ansible collection location = /ansible/.ansible/collections
  executable location = /usr/local/bin/ansible-galaxy
  python version = 3.13.5 (main, Jun 12 2025, 22:38:58) [GCC 14.2.0] (/usr/local/bin/python)
  jinja version = 3.1.6
  libyaml = True
Using /ansible/ansible.cfg as config file
Starting galaxy role install process
Processing role githubixx.etcd 
Opened /root/.ansible/galaxy_token
- downloading role 'etcd', owned by githubixx
- downloading role from https://github.com/githubixx/ansible-role-etcd/archive/14.0.1+3.5.22.tar.gz
- extracting githubixx.etcd to /ansible/.ansible/roles/githubixx.etcd
[WARNING]: - githubixx.etcd was NOT installed successfully: Invalid linkname for tarfile member: path /opt/scripts/ansible/roles/githubixx.etcd is not a subpath of the role
/ansible/ansible-role-etcd-14.0.1-3.5.22
ERROR! - you can use --ignore-errors to skip failed roles and finish processing the list.
```

Correct for 13.2.1+3.5.17:
```bash
# ansible-galaxy install --force githubixx.etcd,13.2.1+3.5.17 -vvv
ansible-galaxy [core 2.18.6]
  config file = /ansible/ansible.cfg
  configured module search path = ['/ansible/.ansible/collections/ansible_collections/debops/debops/plugins/modules']
  ansible python module location = /usr/local/lib/python3.13/site-packages/ansible
  ansible collection location = /ansible/.ansible/collections
  executable location = /usr/local/bin/ansible-galaxy
  python version = 3.13.5 (main, Jun 12 2025, 22:38:58) [GCC 14.2.0] (/usr/local/bin/python)
  jinja version = 3.1.6
  libyaml = True
Using /ansible/ansible.cfg as config file
Starting galaxy role install process
Processing role githubixx.etcd 
Opened /root/.ansible/galaxy_token
- downloading role 'etcd', owned by githubixx
- downloading role from https://github.com/githubixx/ansible-role-etcd/archive/13.2.1+3.5.17.tar.gz
- extracting githubixx.etcd to /ansible/.ansible/roles/githubixx.etcd
- githubixx.etcd (13.2.1+3.5.17) was installed successfully
```